### PR TITLE
update local kernel installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ optional arguments:
                         kernel folder. Default is False.
 ```
 
-The kernel will be stored at `$HOME/.ipython/kernels/`. More information on how to use Apache Spark at NERSC can be found at this [page](http://www.nersc.gov/users/data-analytics/data-analytics-2/spark-distributed-analytic-framework/).
+The kernel will be stored at `$HOME/.local/share/jupyter/kernels/`. More information on how to use Apache Spark at NERSC can be found at this [page](http://www.nersc.gov/users/data-analytics/data-analytics-2/spark-distributed-analytic-framework/).
 
 ### Apache Spark for DESC members (recommended)
 

--- a/makekernel.py
+++ b/makekernel.py
@@ -443,9 +443,8 @@ if __name__ == "__main__":
 
     if not args.local:
         # Kernels are stored here
-        # See http://www.nersc.gov/users/data-analytics/
-        # data-analytics-2/jupyter-and-rstudio/
-        path = '{}/.ipython/kernels/{}'.format(HOME, args.kernelname)
+        # See https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs
+        path = '{}/.local/share/jupyter/kernels/{}'.format(HOME, args.kernelname)
     else:
         path = os.curdir
 


### PR DESCRIPTION
After the ipython --> jupyter transition, the user kernel path should be `~/.local/share/jupyter/kernels` (see https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs). 

While the old one still works, I think it's a good idea to keep kernels installed in the same location (as other DESC kernels). 