### PR TITLE
Release of a kernel for LSSTDESC

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note that he directory `/global/cscratch1/sd/<user>/tmpfiles` will be created to
 
 ### Custom shifter images (recommended for experienced users)
 
-For Spark version 2.3.0+, Spark ran inside of [Shifter](http://www.nersc.gov/research-and-development/user-defined-images/) (Docker for HPC). Since you are inside an image,
+For Spark version 2.3.0+, Spark ran inside of [Shifter](https://www.nersc.gov/research-and-development/user-defined-images/) (Docker for HPC). Since you are inside an image,
 you do not have automatically access to your user-defined environment.
 Therefore you might want to create your Spark shifter image, based on the one NERSC
 provides, but with additional packages you need installed.

--- a/README.md
+++ b/README.md
@@ -12,16 +12,13 @@ Create a kernel with python DESC environment (based on `desc-python`) and Apache
 
 ```
 python desc-kernel.py \
-  -kernelname desc-python-pyspark \
+  -kernelname desc-pyspark \
   -pyspark_args "--master local[4] \
   --driver-memory 32g --executor-memory 32g \
-  --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1 \
-  --conf spark.eventLog.enabled=true \
-  --conf spark.eventLog.dir=file://$SCRATCH/spark/event_logs \
-  --conf spark.history.fs.logDirectory=file://$SCRATCH/spark/event_logs"
+  --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1"
 ```
 
-And then select the kernel `desc-python-pyspark` in the JupyerLab interface.
+And then select the kernel `desc-pyspark` in the JupyerLab interface.
 Note that the folders
 
 - `/global/cscratch1/sd/<user>/tmpfiles`

--- a/desc-kernel.py
+++ b/desc-kernel.py
@@ -43,7 +43,7 @@ def create_desc_startup_file(path, pyspark_args):
     filename: str
         Returns the startup script filename (with full path)
     """
-    filename = os.path.join(path, 'start_desc.sh')
+    filename = os.path.join(path, 'desc-pyspark.sh')
 
     startup = """#!/bin/bash
 # Where the Spark logs will be stored

--- a/desc-kernel.py
+++ b/desc-kernel.py
@@ -59,7 +59,8 @@ mkdir -p ${{SCRATCH}}/tmpfiles
 lSSTCONDA="/global/common/software/lsst/common/miniconda"
 
 # Since the default NERSC Apache Spark runs inside of Shifter, we use
-# a local version of it maintained by Julien Peloton (peloton@lal.in2p3.fr)
+# a custom local version of it. This is maintained by me (Julien Peloton)
+# at NERSC. If you encounter problems, let me know (peloton at lal.in2p3.fr)!
 SPARKPATH="/global/homes/p/peloton/myspark/spark-2.3.2-bin-hadoop2.7"
 
 # Here is the environment needed for Spark to run at NERSC.
@@ -89,7 +90,7 @@ source ${{lSSTCONDA}}/kernels/python.sh
 
     return filename
 
-def create_desc_kernel(path, startupname, kernelname, pyspark_args):
+def create_desc_kernel(path, startupname, kernelname):
     """
     Create a Kernel file with python DESC + Spark env.
     The Spark version is 2.3.2, maintained by J. Peloton at NERSC.

--- a/desc-kernel.py
+++ b/desc-kernel.py
@@ -93,7 +93,7 @@ source ${{lSSTCONDA}}/kernels/python.sh
 def create_desc_kernel(path, startupname, kernelname):
     """
     Create a Kernel file with python DESC + Spark env.
-    The Spark version is 2.3.2, maintained by J. Peloton at NERSC.
+    Maintained by J. Peloton at NERSC.
 
     Parameters
     ----------
@@ -110,7 +110,7 @@ def create_desc_kernel(path, startupname, kernelname):
 
     # Kernel file
     kernel = """{{
-  "display_name": "{} (2.3.2)",
+  "display_name": "{}",
   "language": "python",
   "argv": [
     "{}",

--- a/desc-kernel.py
+++ b/desc-kernel.py
@@ -115,7 +115,7 @@ def create_desc_kernel(path, startupname, kernelname):
   "argv": [
     "{}",
     "-f",
-    "{{connection_file}}"],
+    "{{connection_file}}"]
 }}
     """.format(kernelname, startupname)
 

--- a/desc-kernel.py
+++ b/desc-kernel.py
@@ -65,7 +65,7 @@ SPARKPATH="/global/homes/p/peloton/myspark/spark-2.3.2-bin-hadoop2.7"
 
 # Here is the environment needed for Spark to run at NERSC.
 export SPARK_HOME="${{SPARKPATH}}"
-export PYSPARK_SUBMIT_ARGS="{} pyspark-shell"
+export PYSPARK_SUBMIT_ARGS="{} --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${{SCRATCH}}/spark/event_logs --conf spark.history.fs.logDirectory=file://${{SCRATCH}}/spark/event_logs pyspark-shell"
 export PYTHONSTARTUP="${{SPARKPATH}}/python/pyspark/shell.py"
 
 # Make sure the version of py4j is correct.


### PR DESCRIPTION
This PR adds the official LSST DESC kernel: `desc-pyspark`.

Compared to previous versions, two major changes: 

- The Spark environment is set up inside the startup script (to allow the use of global environment variables). The kernel file becomes minimalist.
- The paths to log and tmp Spark files are included by default (no need to specify it in the `pyspark_args`).