### PR TITLE
Set $SCRATCH if it does not exist

### DIFF
--- a/desc-kernel.py
+++ b/desc-kernel.py
@@ -48,6 +48,9 @@ def create_desc_startup_file(path, pyspark_args):
     startup = """#!/bin/bash
 # Where the Spark logs will be stored
 # Logs can be then be browsed from the Spark UI
+if [ -z ${{SCRATCH}} ]; then
+  SCRATCH=`mktemp -d`
+fi
 LOGDIR=${{SCRATCH}}/spark/event_logs
 mkdir -p ${{LOGDIR}}
 


### PR DESCRIPTION
Based on the work of @yymao (see https://github.com/LSSTDESC/jupyter-kernels/pull/2), this PR adds a check on the existence of $SCRATCH, and, if it does not exist, make a temporary directory and assign $SCRATCH to it.

This proves useful for beavis-ci for example.